### PR TITLE
Add how to nerdfont renderer setting by lua at usage section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,16 @@
 
 ## Usage
 
-Set `"nerdfont"` to `g:fern#renderer` like:
+Set `"nerdfont"` to `g:fern#renderer` in `init.vim` like:
 
 ```vim
 let g:fern#renderer = "nerdfont"
+```
+
+or `init.lua` like:
+
+```lua
+vim.g['fern#renderer'] = 'nerdfont'
 ```
 
 ## See also

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Set `"nerdfont"` to `g:fern#renderer` in `init.vim` like:
 let g:fern#renderer = "nerdfont"
 ```
 
-or `init.lua` like:
+or in `init.lua` like:
 
 ```lua
 vim.g['fern#renderer'] = 'nerdfont'


### PR DESCRIPTION
Add how to nerdfont renderer setting by lua at usage section in readme

# Why

I didn't know that global variables can be set with `vim.g.`.

I feels difficult to find a way to migrate this to lua.

It may be beyond the your scope of responsibility to take,
But feel it would be very helpful to users if you put it in the readme.
If you would be so kind, please.

# Change

- init.vim : `let g:fern#renderer = "nerdfont"`
- init.lua : `vim.g['fern#renderer'] = 'nerdfont'`

# Reference

- [willelz/nvim-lua-guide-ja](https://github.com/willelz/nvim-lua-guide-ja/blob/master/README.ja.md#:~:text=%E6%93%8D%E4%BD%9C%E3%81%A7%E3%81%8D%E3%81%BE%E3%81%99%E3%80%82%3A-,vim.g%5B%27my%23variable%27%5D,-%E5%A4%89%E6%95%B0%E3%82%92%E5%89%8A%E9%99%A4)
- [nvim official guide](https://neovim.io/doc/user/lua.html#vim.g)