### PR TITLE
feat: root_symbol and indent_markers are added

### DIFF
--- a/autoload/fern/renderer/nerdfont.vim
+++ b/autoload/fern/renderer/nerdfont.vim
@@ -21,16 +21,52 @@ function! s:render(nodes) abort
         \ 'leading': g:fern#renderer#nerdfont#leading,
         \ 'padding': g:fern#renderer#nerdfont#padding,
         \ 'root_symbol': g:fern#renderer#nerdfont#root_symbol,
+        \ 'indent_markers': g:fern#renderer#nerdfont#indent_markers,
         \}
   let base = len(a:nodes[0].__key)
+
+  if options.indent_markers
+    let length_nodes = len(a:nodes)
+    let levels = {}
+
+    for i in range(length_nodes - 1, 0, -1)
+      let node = a:nodes[i]
+      let node._renderer_nerdfont_level = len(node.__key) - base
+      let node._renderer_nerdfont_last = get(levels, node._renderer_nerdfont_level, 0) isnot# 1 ? 1 : 0
+
+      for key in keys(levels)
+        if key > node._renderer_nerdfont_level
+          let levels[key] = 0
+        endif
+      endfor
+
+      let levels[node._renderer_nerdfont_level] = 1
+    endfor
+
+    for i in range(length_nodes)
+      let node = a:nodes[i]
+      let last_marker = i is# 0 ? [0] : a:nodes[i - 1]._renderer_nerdfont_marker
+      let node._renderer_nerdfont_marker = [repeat([0], node._renderer_nerdfont_level)][0]
+      let current_length = len(node._renderer_nerdfont_marker)
+
+      for ii in range(min([len(last_marker), current_length]))
+        let node._renderer_nerdfont_marker[ii] = last_marker[ii]
+      endfor
+
+      if node._renderer_nerdfont_last is# 1 && i isnot# 0
+        let node._renderer_nerdfont_marker[current_length - 1] = 1
+      endif
+    endfor
+  endif
+
   let Profile = fern#profile#start('fern#renderer#nerdfont#s:render')
   return s:AsyncLambda.map(copy(a:nodes), { v, -> s:render_node(v, base, options) })
         \.finally({ -> Profile() })
 endfunction
 
 function! s:syntax() abort
-  syntax match FernLeaf   /^\s*\zs.*[^/].*$/ transparent contains=FernLeafSymbol
-  syntax match FernBranch /^\s*\zs.*\/.*$/   transparent contains=FernBranchSymbol
+  syntax match FernLeaf   /\s*\zs.*[^/].*$/ transparent contains=FernLeafSymbol
+  syntax match FernBranch /\s*\zs.*\/.*$/   transparent contains=FernBranchSymbol
   syntax match FernRoot   /\%1l.*/     transparent contains=FernRootText
 
   syntax match FernLeafSymbol   /. / contained nextgroup=FernLeafText
@@ -41,25 +77,47 @@ function! s:syntax() abort
   syntax match FernBranchText /.*\ze.*$/ contained nextgroup=FernBadgeSep
   syntax match FernBadgeSep   //         contained conceal nextgroup=FernBadge
   syntax match FernBadge      /.*/         contained
+
+  syntax match FernIndentMarkers /[│└]/
   setlocal concealcursor=nvic conceallevel=2
 endfunction
 
 function! s:highlight() abort
-  highlight default link FernRootText     Comment
-  highlight default link FernLeafSymbol   Directory
-  highlight default link FernLeafText     None
-  highlight default link FernBranchSymbol Statement
-  highlight default link FernBranchText   Statement
+  highlight default link FernRootText      Comment
+  highlight default link FernLeafSymbol    Directory
+  highlight default link FernLeafText      None
+  highlight default link FernBranchSymbol  Statement
+  highlight default link FernBranchText    Statement
+  highlight default link FernIndentMarkers NonText
 endfunction
 
 function! s:render_node(node, base, options) abort
   let level = len(a:node.__key) - a:base
   if level is# 0
     let suffix = a:node.label =~# '/$' ? '' : '/'
-    let padding = a:options.root_symbol == '' ? '' : a:options.padding
+    let padding = a:options.root_symbol =# '' ? '' : a:options.padding
     return a:options.root_symbol . padding . a:node.label . suffix . '' . a:node.badge
   endif
-  let leading = repeat(a:options.leading, level - 1)
+  let leading = ''
+
+  if a:options.indent_markers
+    let indent_length = len(a:node._renderer_nerdfont_marker)
+
+    for i in range(indent_length)
+      let indent = a:node._renderer_nerdfont_marker[i]
+
+      if indent is# 0
+        let leading = leading . '│ '
+      elseif indent is# 1 && i is# indent_length - 1
+        let leading = leading . '└ '
+      else
+        let leading = leading . '  '
+      endif
+    endfor
+  else
+    let leading = repeat(a:options.leading, level - 1)
+  endif
+
   let symbol = s:get_node_symbol(a:node)
   let suffix = a:node.status ? '/' : ''
   return leading . symbol . a:node.label . suffix . '' . a:node.badge
@@ -95,4 +153,5 @@ call s:Config.config(expand('<sfile>:p'), {
       \ 'leading': ' ',
       \ 'padding': ' ',
       \ 'root_symbol': '',
+      \ 'indent_markers': 0,
       \})

--- a/autoload/fern/renderer/nerdfont.vim
+++ b/autoload/fern/renderer/nerdfont.vim
@@ -19,6 +19,8 @@ endfunction
 function! s:render(nodes) abort
   let options = {
         \ 'leading': g:fern#renderer#nerdfont#leading,
+        \ 'padding': g:fern#renderer#nerdfont#padding,
+        \ 'root_symbol': g:fern#renderer#nerdfont#root_symbol,
         \}
   let base = len(a:nodes[0].__key)
   let Profile = fern#profile#start('fern#renderer#nerdfont#s:render')
@@ -54,7 +56,8 @@ function! s:render_node(node, base, options) abort
   let level = len(a:node.__key) - a:base
   if level is# 0
     let suffix = a:node.label =~# '/$' ? '' : '/'
-    return a:node.label . suffix . '' . a:node.badge
+    let padding = a:options.root_symbol == '' ? '' : a:options.padding
+    return a:options.root_symbol . padding . a:node.label . suffix . '' . a:node.badge
   endif
   let leading = repeat(a:options.leading, level - 1)
   let symbol = s:get_node_symbol(a:node)
@@ -91,4 +94,5 @@ endtry
 call s:Config.config(expand('<sfile>:p'), {
       \ 'leading': ' ',
       \ 'padding': ' ',
+      \ 'root_symbol': '',
       \})

--- a/doc/fern-renderer-nerdfont.txt
+++ b/doc/fern-renderer-nerdfont.txt
@@ -52,6 +52,10 @@ VARIABLE				*fern-renderer-nerdfont-variable*
 	symbol.
 	Default: " "
 
+*g:fern#renderer#nerdfont#root_symbol*
+	A |String| used as a symbol of root node.
+	Default: ""
+
 -----------------------------------------------------------------------------
 COLORS				*fern-renderer-nerdfont-colors*
 

--- a/doc/fern-renderer-nerdfont.txt
+++ b/doc/fern-renderer-nerdfont.txt
@@ -56,6 +56,11 @@ VARIABLE				*fern-renderer-nerdfont-variable*
 	A |String| used as a symbol of root node.
 	Default: ""
 
+*g:fern#renderer#nerdfont#indent_markers*
+	Set 1 to enable fern indent markers.
+	Enabling this option may affect performance.
+	Default: 0
+
 -----------------------------------------------------------------------------
 COLORS				*fern-renderer-nerdfont-colors*
 


### PR DESCRIPTION
Hello again @lambdalisue !! - thanks for the corrections in the [previous pull request](https://github.com/lambdalisue/fern-renderer-nerdfont.vim/pull/19), I have opened this new contribution with all the corrections clean. I hope that this time they meet all the standards of their projects.

Therefore, I recommend that you spend your time to have the necessary standards and guidelines in all Fern-related projects, so that more developers are encouraged to bring more interesting features to the much-loved Fern.

--
Thanks again,
Wuelner.