### PR TITLE
feat: add root_leading option

### DIFF
--- a/autoload/fern/renderer/nerdfont.vim
+++ b/autoload/fern/renderer/nerdfont.vim
@@ -22,6 +22,7 @@ function! s:render(nodes) abort
         \ 'padding': g:fern#renderer#nerdfont#padding,
         \ 'root_symbol': g:fern#renderer#nerdfont#root_symbol,
         \ 'indent_markers': g:fern#renderer#nerdfont#indent_markers,
+        \ 'root_leading': g:fern#renderer#nerdfont#root_leading,
         \}
   let base = len(a:nodes[0].__key)
 
@@ -101,7 +102,8 @@ function! s:render_node(node, base, options) abort
   if level is# 0
     let suffix = a:node.label =~# '/$' ? '' : '/'
     let padding = a:options.root_symbol ==# '' ? '' : a:options.padding
-    return a:options.root_symbol . padding . a:node.label . suffix . '' . a:node.badge
+    let root_leading = s:get_root_leading(a:options)
+    return root_leading . a:options.root_symbol . padding . a:node.label . suffix . '' . a:node.badge
   endif
   let leading = ''
 
@@ -125,7 +127,8 @@ function! s:render_node(node, base, options) abort
 
   let symbol = s:get_node_symbol(a:node)
   let suffix = a:node.status ? '/' : ''
-  return leading . symbol . a:node.label . suffix . '' . a:node.badge
+  let root_leading = s:get_root_leading(a:options)
+  return root_leading . leading . symbol . a:node.label . suffix . '' . a:node.badge
 endfunction
 
 function! s:get_node_symbol(node) abort
@@ -137,6 +140,21 @@ function! s:get_node_symbol(node) abort
     let symbol = s:find(a:node.bufname, 'open')
   endif
   return symbol
+endfunction
+
+" Add a padding on the root level nodes, if 1 then use
+" g:fern#renderer#nerdfont#leading. Otherwise,
+" use value if string
+function! s:get_root_leading(options) abort
+  if a:options.root_leading == 1
+    return a:options.leading
+  endif
+
+  if type(a:options.root_leading) == type('')
+    return a:options.root_leading
+  endif
+
+  return ''
 endfunction
 
 " Check if nerdfont has installed or not
@@ -159,4 +177,5 @@ call s:Config.config(expand('<sfile>:p'), {
       \ 'padding': ' ',
       \ 'root_symbol': '',
       \ 'indent_markers': 0,
+      \ 'root_leading': 1,
       \})

--- a/autoload/fern/renderer/nerdfont.vim
+++ b/autoload/fern/renderer/nerdfont.vim
@@ -102,8 +102,7 @@ function! s:render_node(node, base, options) abort
   if level is# 0
     let suffix = a:node.label =~# '/$' ? '' : '/'
     let padding = a:options.root_symbol ==# '' ? '' : a:options.padding
-    let root_leading = s:get_root_leading(a:options)
-    return root_leading . a:options.root_symbol . padding . a:node.label . suffix . '' . a:node.badge
+    return a:options.root_leading . a:options.root_symbol . padding . a:node.label . suffix . '' . a:node.badge
   endif
   let leading = ''
 
@@ -127,8 +126,7 @@ function! s:render_node(node, base, options) abort
 
   let symbol = s:get_node_symbol(a:node)
   let suffix = a:node.status ? '/' : ''
-  let root_leading = s:get_root_leading(a:options)
-  return root_leading . leading . symbol . a:node.label . suffix . '' . a:node.badge
+  return a:options.root_leading . leading . symbol . a:node.label . suffix . '' . a:node.badge
 endfunction
 
 function! s:get_node_symbol(node) abort
@@ -140,21 +138,6 @@ function! s:get_node_symbol(node) abort
     let symbol = s:find(a:node.bufname, 'open')
   endif
   return symbol
-endfunction
-
-" Add a padding on the root level nodes, if 1 then use
-" g:fern#renderer#nerdfont#leading. Otherwise,
-" use value if string
-function! s:get_root_leading(options) abort
-  if a:options.root_leading == 1
-    return a:options.leading
-  endif
-
-  if type(a:options.root_leading) == type('')
-    return a:options.root_leading
-  endif
-
-  return ''
 endfunction
 
 " Check if nerdfont has installed or not
@@ -177,5 +160,5 @@ call s:Config.config(expand('<sfile>:p'), {
       \ 'padding': ' ',
       \ 'root_symbol': '',
       \ 'indent_markers': 0,
-      \ 'root_leading': 1,
+      \ 'root_leading': ' ',
       \})

--- a/autoload/fern/renderer/nerdfont.vim
+++ b/autoload/fern/renderer/nerdfont.vim
@@ -162,3 +162,5 @@ call s:Config.config(expand('<sfile>:p'), {
       \ 'indent_markers': 0,
       \ 'root_leading': ' ',
       \})
+
+let g:fern#renderer#nerdfont#root_leading = get(g:, 'fern#renderer#nerdfont#root_leading', g:fern#renderer#nerdfont#leading)

--- a/doc/fern-renderer-nerdfont.txt
+++ b/doc/fern-renderer-nerdfont.txt
@@ -62,23 +62,20 @@ VARIABLE				*fern-renderer-nerdfont-variable*
 	Default: 0
 
 *g:fern#renderer#nerdfont#root_leading*
-	Add a lead (padding) in front of the root level nodes.
-        By default uses *g:fern#renderer#nerdfont#leading* when
-        set to 1, when it's 0 no padding is added.
+	A |String| to add a lead (padding) in front
+        of the root level nodes.
+	Default: " "
 
-        When it's a |String|, that value will be used instead
-        in front of the root level nodes.
+        Note, you can set it to *g:fern#renderer#nerdfont#leading*
+        if you want consistent padding between your root and inner
+        nodes, like below:
 
-	Default: 1
-
-        Example, if root_leading set to 1 nodes will look like
-        the following (shown with *'number'* option enabled):
 >
-    1│ root
-    2│  file1.txt
-    3│  file2.txt
+    let g:fern#renderer#nerdfont#root_leading = get(g:, 'fern#renderer#nerdfont#leading', ' ')
 <
-        With root_leading set to 0:
+
+        Example, with root_leading set to "" (shown below with
+        *number* set):
 >
     1│root
     2│ file1.txt

--- a/doc/fern-renderer-nerdfont.txt
+++ b/doc/fern-renderer-nerdfont.txt
@@ -64,15 +64,7 @@ VARIABLE				*fern-renderer-nerdfont-variable*
 *g:fern#renderer#nerdfont#root_leading*
 	A |String| to add a lead (padding) in front
         of the root level nodes.
-	Default: " "
-
-        Note, you can set it to *g:fern#renderer#nerdfont#leading*
-        if you want consistent padding between your root and inner
-        nodes, like below:
-
->
-    let g:fern#renderer#nerdfont#root_leading = get(g:, 'fern#renderer#nerdfont#leading', ' ')
-<
+	Default: *g:fern#renderer#nerdfont#leading*
 
         Example, with root_leading set to "" (shown below with
         *number* set):

--- a/doc/fern-renderer-nerdfont.txt
+++ b/doc/fern-renderer-nerdfont.txt
@@ -64,7 +64,7 @@ VARIABLE				*fern-renderer-nerdfont-variable*
 *g:fern#renderer#nerdfont#root_leading*
 	A |String| to add a lead (padding) in front
         of the root level nodes.
-	Default: *g:fern#renderer#nerdfont#leading*
+	Default: |g:fern#renderer#nerdfont#leading|
 
         Example, with root_leading set to "" (shown below with
         *number* set):

--- a/doc/fern-renderer-nerdfont.txt
+++ b/doc/fern-renderer-nerdfont.txt
@@ -61,6 +61,36 @@ VARIABLE				*fern-renderer-nerdfont-variable*
 	Enabling this option may affect performance.
 	Default: 0
 
+*g:fern#renderer#nerdfont#root_leading*
+	Add a lead (padding) in front of the root level nodes.
+        By default uses *g:fern#renderer#nerdfont#leading* when
+        set to 1, when it's 0 no padding is added.
+
+        When it's a |String|, that value will be used instead
+        in front of the root level nodes.
+
+	Default: 1
+
+        Example, if root_leading set to 1 nodes will look like
+        the following (shown with *'number'* option enabled):
+>
+    1│ root
+    2│  file1.txt
+    3│  file2.txt
+<
+        With root_leading set to 0:
+>
+    1│root
+    2│ file1.txt
+    3│ file2.txt
+<
+        With root_leading set to "@  ":
+>
+    1│@  root
+    2│@   file1.txt
+    3│@   file2.txt
+<
+
 -----------------------------------------------------------------------------
 COLORS				*fern-renderer-nerdfont-colors*
 


### PR DESCRIPTION
Addresses #21 

I didn't know what to call it, but since it's similar to `g:fern#renderer#nerdfont#leading` option I decided to call it `g:fern#renderer#nerdfont#root_leading`.

So let me know if any changes are needed.

This option will add a space in front of the root nodes, by default will use `g:fern#renderer#nerdfont#leading` to add the spacing. Else user can add their own custom string.

When `let g:fern#renderer#nerdfont#root_leading = 0`:

<img width="409" alt="Screen Shot 2022-12-04 at 16 39 20" src="https://user-images.githubusercontent.com/3767728/205514381-2bcdea8f-6978-4b98-b1ad-e9d34299c86c.png">

When `let g:fern#renderer#nerdfont#root_leading = 1` (Default):

<img width="409" alt="Screen Shot 2022-12-04 at 16 41 36" src="https://user-images.githubusercontent.com/3767728/205514436-b532e558-7028-438d-b94a-b5274ee74300.png">
