### PR TITLE
Change default variable of "g:fern#renderer#nerdfont#padding" to "" in doc.

### DIFF
--- a/doc/fern-renderer-nerdfont.txt
+++ b/doc/fern-renderer-nerdfont.txt
@@ -50,7 +50,7 @@ VARIABLE				*fern-renderer-nerdfont-variable*
 	A |String| which is placed between the symobl and the label.
 	Add more spaces to regulate the position of the label after the
 	symbol.
-	Default: " "
+	Default: ""
 
 *g:fern#renderer#nerdfont#root_symbol*
 	A |String| used as a symbol of root node.


### PR DESCRIPTION
After [this change](https://github.com/lambdalisue/fern-renderer-nerdfont.vim/commit/e472ea1b57c39a651fe0fee3907fbfc5ad296446#diff-5dd52d7bfda661c13fe174787cffdd3ca9bd8dbf6cec269135ce53f4e2a73d25L160), the default value of `g:fern#renderer#nerdfont#padding` is set to `""`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the default value of a configuration variable in the renderer documentation from a single space to an empty string for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->