### PR TITLE
Add '/' to escape PATTERN

### DIFF
--- a/autoload/fern/renderer/nerdfont.vim
+++ b/autoload/fern/renderer/nerdfont.vim
@@ -1,6 +1,6 @@
 scriptencoding utf-8
 
-let s:PATTERN = '^$~.*[]\'
+let s:PATTERN = '^$~.*[]\/'
 let s:Config = vital#fern#import('Config')
 let s:AsyncLambda = vital#fern#import('Async.Lambda')
 


### PR DESCRIPTION
Add '/' to escape pattern of root_symbol otherwise the symbol clashes with syntax match command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy of pattern matching in the application by updating the regular expression pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->