### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Usage
 
-Set `"nerdfont"` to `g:fern#renderer` like:
+Set `g:fern#renderer` to `"nerdfont"` like:
 
 ```vim
 let g:fern#renderer = "nerdfont"


### PR DESCRIPTION
Set x to y means `x := y`, not `y := x`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
    - Updated README to reflect the changes in the configuration settings for Vim script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->